### PR TITLE
Fix formatting of the engine code (Iteration #1)

### DIFF
--- a/CubeDemo/CubeDemo.cpp
+++ b/CubeDemo/CubeDemo.cpp
@@ -158,8 +158,8 @@ bool CubeDemo::LoadContent()
 
 	ThrowIfFailed(device->CreatePipelineState(&pipelineStateStreamDesc, IID_PPV_ARGS(&m_pipelineState)));
 
-	auto fenceValue = commandQueue->ExecuteCommandList(commandList);
-	commandQueue->WaitForFenceValue(fenceValue);
+	auto fenceValue = commandQueue->executeCommandList(commandList);
+	commandQueue->waitForFenceValue(fenceValue);
 
 	m_contentLoaded = true;
 
@@ -242,11 +242,11 @@ void CubeDemo::OnRender(RenderEventArgs& e)
 	// presenting
 	{
 		TransitionResource(commandList, backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
-		m_fenceValues[currentBackBufferIndex] = commandQueue->ExecuteCommandList(commandList);
+		m_fenceValues[currentBackBufferIndex] = commandQueue->executeCommandList(commandList);
 
 		UINT presentFlags = Application::Get().IsTearingSupported() && !m_vsync ? DXGI_PRESENT_ALLOW_TEARING : 0;
 		currentBackBufferIndex = m_window->Present((m_vsync ? 1 : 0), presentFlags);
-		commandQueue->WaitForFenceValue(m_fenceValues[currentBackBufferIndex]);
+		commandQueue->waitForFenceValue(m_fenceValues[currentBackBufferIndex]);
 	}
 }
 

--- a/CubeDemo/CubeDemo.cpp
+++ b/CubeDemo/CubeDemo.cpp
@@ -55,7 +55,7 @@ bool CubeDemo::LoadContent()
 {
 	auto device = Application::Get().GetDevice();
 	auto commandQueue = Application::Get().GetCommandQueue(D3D12_COMMAND_LIST_TYPE_COPY);
-	auto commandList = commandQueue->GetCommandList();
+	auto commandList = commandQueue->getCommandList();
 
 	// Uploading vertex buffer data
 	cp<ID3D12Resource> intermediateVertexBuffer;
@@ -202,7 +202,7 @@ void CubeDemo::OnUpdate(UpdateEventArgs& e)
 void CubeDemo::OnRender(RenderEventArgs& e)
 {
 	auto commandQueue = Application::Get().GetCommandQueue(D3D12_COMMAND_LIST_TYPE_DIRECT);
-	auto commandList = commandQueue->GetCommandList();
+	auto commandList = commandQueue->getCommandList();
 	// no need to reset the command list (check CommandQueue::GetCommandList function above)
 
 	UINT currentBackBufferIndex = m_window->GetCurrentBackBufferIndex();

--- a/Engine/.clang-format
+++ b/Engine/.clang-format
@@ -1,0 +1,27 @@
+---
+# With 4 columns indentation.
+BasedOnStyle: WebKit
+IndentWidth: 4
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+# Override the break before braces and use Allman (aka add a new line after every bracket)
+BreakBeforeBraces: Allman
+# to Use in case with custom (specify Custom for BreakBeforeBraces to make this work)
+# BraceWrapping:
+#    AfterEnum: true
+#    AfterStruct: true
+#    AfterClass: true
+
+
+# Indent in all namespaces
+NamespaceIndentation: All
+
+# TODO add line break after public/protected/private
+...
+
+
+# for reference:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html

--- a/Engine/.clang-format
+++ b/Engine/.clang-format
@@ -19,7 +19,11 @@ BreakBeforeBraces: Allman
 # Indent in all namespaces
 NamespaceIndentation: All
 
-# TODO add line break after public/protected/private
+
+# Start empty line after public/private..etc only if there is some logic after it
+EmptyLineBeforeAccessModifier: LogicalBlock
+# Seems this one is not supported for my clang-format version TODO check it later
+# EmptyLineAfterAccessModifierStyle: Always
 ...
 
 

--- a/Engine/include/Mizu/CommandQueue.hpp
+++ b/Engine/include/Mizu/CommandQueue.hpp
@@ -8,45 +8,45 @@
 
 namespace Mizu
 {
-class CommandQueue
-{
-public:
-    CommandQueue(Microsoft::WRL::ComPtr<ID3D12Device2> device, D3D12_COMMAND_LIST_TYPE type);
-    virtual ~CommandQueue();
-
-    uint64_t executeCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> commandList);
-
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> GetCommandList();
-
-    uint64_t signal();
-    bool isFenceComplete(uint64_t fenceValue);
-    void waitForFenceValue(uint64_t fenceValue);
-    void flush();
-
-    // TODO find a better solution than this one to close the window handle
-    void closeHandle() const { ::CloseHandle(m_FenceEvent); }
-
-    [[nodiscard]] Microsoft::WRL::ComPtr<ID3D12CommandQueue> getCommandQueue() const;
-
-protected:
-    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CreateCommandAllocator();
-
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CreateCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator);
-
-    struct CommandAllocatorEntry
+    class CommandQueue
     {
-        uint64_t fenceValue;
-        Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
+    public:
+        CommandQueue(Microsoft::WRL::ComPtr<ID3D12Device2> device, D3D12_COMMAND_LIST_TYPE type);
+        virtual ~CommandQueue();
+
+        uint64_t executeCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> commandList);
+
+        Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> getCommandList();
+
+        uint64_t signal();
+        bool isFenceComplete(uint64_t fenceValue);
+        void waitForFenceValue(uint64_t fenceValue);
+        void flush();
+
+        // TODO find a better solution than this one to close the window handle
+        void closeHandle() const { ::CloseHandle(m_fenceEvent); }
+
+        [[nodiscard]] Microsoft::WRL::ComPtr<ID3D12CommandQueue> getCommandQueue() const;
+
+    protected:
+        Microsoft::WRL::ComPtr<ID3D12CommandAllocator> createCommandAllocator();
+
+        Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> createCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator);
+
+        struct CommandAllocatorEntry
+        {
+            uint64_t fenceValue;
+            Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
+        };
+
+        D3D12_COMMAND_LIST_TYPE m_commandListType;
+        Microsoft::WRL::ComPtr<ID3D12Device2> m_device;
+        Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_commandQueue;
+        Microsoft::WRL::ComPtr<ID3D12Fence> m_fence;
+        HANDLE m_fenceEvent;
+        uint64_t m_fenceValue;
+
+        std::queue<CommandAllocatorEntry> m_commandAllocatorQueue;
+        std::queue<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>> m_commandListQueue;
     };
-
-    D3D12_COMMAND_LIST_TYPE m_CommandListType;
-    Microsoft::WRL::ComPtr<ID3D12Device2> m_Device;
-    Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_CommandQueue;
-    Microsoft::WRL::ComPtr<ID3D12Fence> m_Fence;
-    HANDLE m_FenceEvent;
-    uint64_t m_FenceValue;
-
-    std::queue<CommandAllocatorEntry> m_CommandAllocatorQueue;
-    std::queue<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>> m_CommandListQueue;
-};
 }

--- a/Engine/include/Mizu/CommandQueue.hpp
+++ b/Engine/include/Mizu/CommandQueue.hpp
@@ -3,54 +3,50 @@
 #include <d3dx12.h>
 #include <wrl.h>
 
-#include<queue>
-#include<cstdint>
-
-
+#include <cstdint>
+#include <queue>
 
 namespace Mizu
 {
-	class CommandQueue
-	{
-	public:
-		CommandQueue(Microsoft::WRL::ComPtr<ID3D12Device2> device, D3D12_COMMAND_LIST_TYPE type);
-		virtual ~CommandQueue();
+class CommandQueue
+{
+public:
+    CommandQueue(Microsoft::WRL::ComPtr<ID3D12Device2> device, D3D12_COMMAND_LIST_TYPE type);
+    virtual ~CommandQueue();
 
-		uint64_t ExecuteCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>  commandList);
+    uint64_t executeCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> commandList);
 
-		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> GetCommandList();
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> GetCommandList();
 
-		uint64_t Signal();
-		bool IsFenceComplete(uint64_t fenceValue);
-		void WaitForFenceValue(uint64_t fenceValue);
-		void Flush();
+    uint64_t signal();
+    bool isFenceComplete(uint64_t fenceValue);
+    void waitForFenceValue(uint64_t fenceValue);
+    void flush();
 
-		// TODO find a better solution than this one to close the window handle
-		void CloseHandle() { ::CloseHandle(m_FenceEvent); }
+    // TODO find a better solution than this one to close the window handle
+    void closeHandle() const { ::CloseHandle(m_FenceEvent); }
 
-		Microsoft::WRL::ComPtr<ID3D12CommandQueue> GetCommandQueue() const;
+    [[nodiscard]] Microsoft::WRL::ComPtr<ID3D12CommandQueue> getCommandQueue() const;
 
-	protected:
+protected:
+    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CreateCommandAllocator();
 
-		Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CreateCommandAllocator();
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CreateCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator);
 
-		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CreateCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator);
+    struct CommandAllocatorEntry
+    {
+        uint64_t fenceValue;
+        Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
+    };
 
-		struct CommandAllocatorEntry
-		{
-			uint64_t fenceValue;
-			Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
-		};
+    D3D12_COMMAND_LIST_TYPE m_CommandListType;
+    Microsoft::WRL::ComPtr<ID3D12Device2> m_Device;
+    Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_CommandQueue;
+    Microsoft::WRL::ComPtr<ID3D12Fence> m_Fence;
+    HANDLE m_FenceEvent;
+    uint64_t m_FenceValue;
 
-		D3D12_COMMAND_LIST_TYPE m_CommandListType;
-		Microsoft::WRL::ComPtr<ID3D12Device2> m_Device;
-		Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_CommandQueue;
-		Microsoft::WRL::ComPtr<ID3D12Fence> m_Fence;
-		HANDLE m_FenceEvent;
-		uint64_t m_FenceValue;
-
-		std::queue<CommandAllocatorEntry> m_CommandAllocatorQueue;
-		std::queue<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>> m_CommandListQueue;
-	};
+    std::queue<CommandAllocatorEntry> m_CommandAllocatorQueue;
+    std::queue<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>> m_CommandListQueue;
+};
 }
-

--- a/Engine/src/Application.cpp
+++ b/Engine/src/Application.cpp
@@ -237,13 +237,13 @@ namespace Mizu
 		switch (type)
 		{
 		case D3D12_COMMAND_LIST_TYPE_COPY:
-			return m_copyCommandQueue->GetCommandList();
+			return m_copyCommandQueue->getCommandList();
 
 		case D3D12_COMMAND_LIST_TYPE_COMPUTE:
-			return m_computeCommandQueue->GetCommandList();
+			return m_computeCommandQueue->getCommandList();
 
 		default:
-			return m_directCommandQueue->GetCommandList();
+			return m_directCommandQueue->getCommandList();
 		}
 	}
 

--- a/Engine/src/Application.cpp
+++ b/Engine/src/Application.cpp
@@ -348,16 +348,16 @@ namespace Mizu
 
 	void Application::Flush()
 	{
-		m_directCommandQueue->Flush();
-		m_copyCommandQueue->Flush();
-		m_computeCommandQueue->Flush();
+		m_directCommandQueue->flush();
+		m_copyCommandQueue->flush();
+		m_computeCommandQueue->flush();
 	}
 
 	void Mizu::Application::Close()
 	{
-		m_directCommandQueue->CloseHandle();
-		m_copyCommandQueue->CloseHandle();
-		m_computeCommandQueue->CloseHandle();
+		m_directCommandQueue->closeHandle();
+		m_copyCommandQueue->closeHandle();
+		m_computeCommandQueue->closeHandle();
 
 		m_windowsNameMap.clear();
 		m_windowsHwndMap.clear();

--- a/Engine/src/CommandQueue.cpp
+++ b/Engine/src/CommandQueue.cpp
@@ -34,7 +34,7 @@ namespace Mizu
 
 	}
 
-	uint64_t CommandQueue::ExecuteCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>  commandList)
+	uint64_t CommandQueue::executeCommandList(Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2>  commandList)
 	{
 		commandList->Close();
 
@@ -47,7 +47,7 @@ namespace Mizu
 		};
 
 		m_CommandQueue->ExecuteCommandLists(1, ppCommandList);
-		uint64_t fenceValue = Signal();
+		uint64_t fenceValue = signal();
 
 		m_CommandAllocatorQueue.emplace(CommandAllocatorEntry{ fenceValue, commandAllocator });
 		m_CommandListQueue.push(commandList);
@@ -65,7 +65,7 @@ namespace Mizu
 		cp<ID3D12CommandAllocator> commandAllocator;
 
 		// reuse the command allocator we have if it's already finished 
-		if (!m_CommandAllocatorQueue.empty() && IsFenceComplete(m_CommandAllocatorQueue.front().fenceValue))
+		if (!m_CommandAllocatorQueue.empty() && isFenceComplete(m_CommandAllocatorQueue.front().fenceValue))
 		{
 			commandAllocator = m_CommandAllocatorQueue.front().commandAllocator;
 			m_CommandAllocatorQueue.pop();
@@ -97,32 +97,32 @@ namespace Mizu
 		return commandList;
 	}
 
-	uint64_t CommandQueue::Signal()
+	uint64_t CommandQueue::signal()
 	{
 		uint64_t newFenceVal = ++m_FenceValue;
 		ThrowIfFailed(m_CommandQueue->Signal(m_Fence.Get(), newFenceVal));
 		return newFenceVal;
 	}
 
-	bool CommandQueue::IsFenceComplete(uint64_t fenceValue)
+	bool CommandQueue::isFenceComplete(uint64_t fenceValue)
 	{
 		return m_Fence->GetCompletedValue() >= fenceValue;
 	}
 
-	void CommandQueue::WaitForFenceValue(uint64_t fenceValue)
+	void CommandQueue::waitForFenceValue(uint64_t fenceValue)
 	{
-		if (!IsFenceComplete(fenceValue))
+		if (!isFenceComplete(fenceValue))
 		{
 			m_Fence->SetEventOnCompletion(fenceValue, m_FenceEvent);
 			::WaitForSingleObject(m_FenceEvent, DWORD_MAX);
 		}
 	}
-	void CommandQueue::Flush()
+	void CommandQueue::flush()
 	{
-		WaitForFenceValue(Signal());
+		waitForFenceValue(signal());
 	}
 
-	Microsoft::WRL::ComPtr<ID3D12CommandQueue> CommandQueue::GetCommandQueue() const
+	Microsoft::WRL::ComPtr<ID3D12CommandQueue> CommandQueue::getCommandQueue() const
 	{
 		return m_CommandQueue;
 	}

--- a/Engine/src/CommandQueue.cpp
+++ b/Engine/src/CommandQueue.cpp
@@ -12,21 +12,21 @@ namespace Mizu
 	using cp = Microsoft::WRL::ComPtr<T>;
 
 	CommandQueue::CommandQueue(Microsoft::WRL::ComPtr<ID3D12Device2> device, D3D12_COMMAND_LIST_TYPE type) :
-		m_FenceValue(0),
-		m_Device(device),
-		m_CommandListType(type)
+		m_fenceValue(0),
+		m_device(device),
+		m_commandListType(type)
 	{
 		D3D12_COMMAND_QUEUE_DESC des = {};
 		des.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
 		des.NodeMask = 0;
 		des.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
-		des.Type = m_CommandListType;
+		des.Type = m_commandListType;
 
-		ThrowIfFailed(m_Device->CreateCommandQueue(&des, IID_PPV_ARGS(&m_CommandQueue)));
-		ThrowIfFailed(m_Device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_Fence)));
-		m_FenceEvent = ::CreateEvent(NULL, FALSE, FALSE, NULL);
+		ThrowIfFailed(m_device->CreateCommandQueue(&des, IID_PPV_ARGS(&m_commandQueue)));
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceEvent = ::CreateEvent(NULL, FALSE, FALSE, NULL);
 
-		assert(m_FenceEvent && "Failed to create the fence event handle!");
+		assert(m_fenceEvent && "Failed to create the fence event handle!");
 	}
 
 	CommandQueue::~CommandQueue()
@@ -46,11 +46,11 @@ namespace Mizu
 			commandList.Get()
 		};
 
-		m_CommandQueue->ExecuteCommandLists(1, ppCommandList);
+		m_commandQueue->ExecuteCommandLists(1, ppCommandList);
 		uint64_t fenceValue = signal();
 
-		m_CommandAllocatorQueue.emplace(CommandAllocatorEntry{ fenceValue, commandAllocator });
-		m_CommandListQueue.push(commandList);
+		m_commandAllocatorQueue.emplace(CommandAllocatorEntry{ fenceValue, commandAllocator });
+		m_commandListQueue.push(commandList);
 
 
 		// because ownership was moved to the ComPtr in the commandAllocatorQueue, so it's safe to release now
@@ -59,35 +59,35 @@ namespace Mizu
 		return fenceValue;
 	}
 
-	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CommandQueue::GetCommandList()
+	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CommandQueue::getCommandList()
 	{
 		cp<ID3D12GraphicsCommandList2> commandList;
 		cp<ID3D12CommandAllocator> commandAllocator;
 
 		// reuse the command allocator we have if it's already finished 
-		if (!m_CommandAllocatorQueue.empty() && isFenceComplete(m_CommandAllocatorQueue.front().fenceValue))
+		if (!m_commandAllocatorQueue.empty() && isFenceComplete(m_commandAllocatorQueue.front().fenceValue))
 		{
-			commandAllocator = m_CommandAllocatorQueue.front().commandAllocator;
-			m_CommandAllocatorQueue.pop();
+			commandAllocator = m_commandAllocatorQueue.front().commandAllocator;
+			m_commandAllocatorQueue.pop();
 
 			ThrowIfFailed(commandAllocator->Reset());
 		}
 		else // or create a new one
 		{
-			commandAllocator = CreateCommandAllocator();
+			commandAllocator = createCommandAllocator();
 		}
 
 
-		if (!m_CommandListQueue.empty())
+		if (!m_commandListQueue.empty())
 		{
-			commandList = m_CommandListQueue.front();
-			m_CommandListQueue.pop();
+			commandList = m_commandListQueue.front();
+			m_commandListQueue.pop();
 
 			ThrowIfFailed(commandList->Reset(commandAllocator.Get(), nullptr));
 		}
 		else
 		{
-			commandList = CreateCommandList(commandAllocator);
+			commandList = createCommandList(commandAllocator);
 		}
 
 		// we associate the command allocator with the command list so that we can retrieve the command allocator from the command list when it is executed
@@ -99,22 +99,22 @@ namespace Mizu
 
 	uint64_t CommandQueue::signal()
 	{
-		uint64_t newFenceVal = ++m_FenceValue;
-		ThrowIfFailed(m_CommandQueue->Signal(m_Fence.Get(), newFenceVal));
+		uint64_t newFenceVal = ++m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), newFenceVal));
 		return newFenceVal;
 	}
 
 	bool CommandQueue::isFenceComplete(uint64_t fenceValue)
 	{
-		return m_Fence->GetCompletedValue() >= fenceValue;
+		return m_fence->GetCompletedValue() >= fenceValue;
 	}
 
 	void CommandQueue::waitForFenceValue(uint64_t fenceValue)
 	{
 		if (!isFenceComplete(fenceValue))
 		{
-			m_Fence->SetEventOnCompletion(fenceValue, m_FenceEvent);
-			::WaitForSingleObject(m_FenceEvent, DWORD_MAX);
+			m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent);
+			::WaitForSingleObject(m_fenceEvent, DWORD_MAX);
 		}
 	}
 	void CommandQueue::flush()
@@ -124,22 +124,22 @@ namespace Mizu
 
 	Microsoft::WRL::ComPtr<ID3D12CommandQueue> CommandQueue::getCommandQueue() const
 	{
-		return m_CommandQueue;
+		return m_commandQueue;
 	}
 
 
-	Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CommandQueue::CreateCommandAllocator()
+	Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CommandQueue::createCommandAllocator()
 	{
 		cp<ID3D12CommandAllocator> commandAllocator;
-		ThrowIfFailed(m_Device->CreateCommandAllocator(m_CommandListType, IID_PPV_ARGS(&commandAllocator)));
+		ThrowIfFailed(m_device->CreateCommandAllocator(m_commandListType, IID_PPV_ARGS(&commandAllocator)));
 
 		return commandAllocator;
 	}
 
-	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CommandQueue::CreateCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator)
+	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList2> CommandQueue::createCommandList(Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator)
 	{
 		cp<ID3D12GraphicsCommandList2> commandList;
-		ThrowIfFailed(m_Device->CreateCommandList(0, m_CommandListType, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+		ThrowIfFailed(m_device->CreateCommandList(0, m_commandListType, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
 		// no need to close it inside our class 
 		//ThrowIfFailed(commandList->Close());

--- a/Engine/src/Window.cpp
+++ b/Engine/src/Window.cpp
@@ -141,7 +141,7 @@ namespace Mizu
 		scDesc.Flags = CheckTearingSupport() ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
 		// get the COM ptr
-		auto commandQueue = command_queue_sptr->GetCommandQueue();
+		auto commandQueue = command_queue_sptr->getCommandQueue();
 
 		ThrowIfFailed(f4->CreateSwapChainForHwnd(commandQueue.Get(), m_hWnd, &scDesc, nullptr, nullptr, &swapChain1));
 


### PR DESCRIPTION
What was done in this MR:
1. Add initial clang format
2. Try it by applying it to CommandQueue class
3. Fix everything in Mizu that is not inside the namespace mizu